### PR TITLE
feat: Wizard TreatmentResource

### DIFF
--- a/app/Enums/EventGradePainEnum.php
+++ b/app/Enums/EventGradePainEnum.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Enums;
+use Filament\Support\Contracts\HasLabel;
+
+enum EventGradePainEnum: string implements HasLabel
+{
+    //
+    case Mild = 'mild';
+    case Moderate = 'moderate';
+    case Severe = 'severe';
+    public static function all(): array
+    {
+        return array_map(fn($status) => $status->value, EventGradePainEnum::cases());
+    }
+    public function getLabel(): string
+    {
+        return match ($this) {
+            self::Mild => 'Mild',
+            self::Moderate => 'Moderate',
+            self::Severe => 'Severe',
+        };
+    }
+}

--- a/app/Enums/EventStatusEnum.php
+++ b/app/Enums/EventStatusEnum.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Enums;
+use Filament\Support\Contracts\HasLabel;
+
+enum EventStatusEnum: string implements HasLabel
+{
+    case Pending = 'pending';
+    case Completed = 'completed';
+    case Canceled = 'canceled';
+
+    public static function all(): array
+    {
+        return array_map(fn($status) => $status->value, EventStatusEnum::cases());
+    }
+    
+    public function getLabel(): string
+    {
+        return match ($this) {
+            self::Pending => 'Pending',
+            self::Completed => 'Completed',
+            self::Canceled => 'Canceled',
+        };
+    }
+}

--- a/app/Enums/TreatmentFirstRoute.php
+++ b/app/Enums/TreatmentFirstRoute.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Enums;
+use Filament\Support\Contracts\HasLabel;
+
+enum TreatmentFirstRoute: string implements HasLabel
+{
+    case Left = 'left';
+    case Right = 'right';
+    case Indifferent = 'indifferent';
+
+    public static function all (): array{
+        return array_map(fn($status) => $status->value, TreatmentFirstRoute::cases());
+    }
+    public function getLabel(): string
+    {
+        return match ($this) {
+            self::Left => 'Left',
+            self::Right => 'Right',
+            self::Indifferent => 'Indifferent',
+        };
+    }
+}

--- a/app/Enums/TreatmentFrequency.php
+++ b/app/Enums/TreatmentFrequency.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Enums;
+use Filament\Support\Contracts\HasLabel;
+
+enum TreatmentFrequency: int implements HasLabel
+{
+    case Every4Hours = 4;
+    case Every6Hours = 6;
+    case Every8Hours = 8;
+    case Every12Hours = 12;
+    case Every24Hours = 24;
+
+    public static function all (): array{
+        return array_map(fn($status) => $status->value, TreatmentFrequency::cases());
+    }
+    public static function minHours() : int {
+        return 4;
+    }
+    public static function maxHours() : int {
+        return 120;
+    }
+    public static function helperText() : string {
+        $minHours = self::minHours();
+        $maxHours = self::maxHours();
+        return "Enter the frequency in hours (e.g., every $minHours hours). Must be between $minHours and $maxHours hours.";
+    }
+    public function getLabel(): string
+    {
+        return match ($this) {
+            self::Every4Hours => 'Every 4 hours',
+            self::Every6Hours => 'Every 6 hours',
+            self::Every8Hours => 'Every 8 hours',
+            self::Every12Hours => 'Every 12 hours',
+            self::Every24Hours => 'Every 24 hours',
+        };
+    }
+
+}

--- a/app/Enums/TreatmentLocation.php
+++ b/app/Enums/TreatmentLocation.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Enums;
+use Filament\Support\Contracts\HasLabel;
+
+enum TreatmentLocation: string implements HasLabel
+{
+    //
+    case Arms = 'arms';
+    case Legs = 'legs';
+    case Chest = 'chest';
+    case Abdomen = 'abdomen';
+    case Other = 'other';
+
+    public static function all (): array{
+        return array_map(fn($status) => $status->value, TreatmentLocation::cases());
+    }
+    public function getLabel(): string
+    {
+        return match ($this) {
+            self::Arms => 'Arms',
+            self::Legs => 'Legs',
+            self::Chest => 'Chest',
+            self::Abdomen => 'Abdomen',
+            self::Other => 'Other'
+        };
+    }
+}

--- a/app/Enums/TreatmentVialType.php
+++ b/app/Enums/TreatmentVialType.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Enums;
+use Filament\Support\Contracts\HasColor;
+use Filament\Support\Contracts\HasIcon;
+use Filament\Support\Contracts\HasLabel;
+
+enum TreatmentVialType: string implements HasLabel
+{
+    //
+    case Oral = "oral";
+    case Injection = "injection";
+    case Other = "other";
+
+    public static function all (): array{
+        return array_map(fn($status) => $status->value, TreatmentVialType::cases());
+    }
+    public function getLabel(): string
+    {
+        return match ($this) {
+            self::Oral => 'Oral',
+            self::Injection => 'Injection',
+            self::Other => 'Other',
+        };
+    }
+}

--- a/app/Filament/Resources/EventResource.php
+++ b/app/Filament/Resources/EventResource.php
@@ -26,9 +26,6 @@ class EventResource extends Resource
     {
         return $form
             ->schema([
-                Forms\Components\Select::make('medicine_id')
-                    ->relationship('medicine', 'name')
-                    ->required(),
                 Forms\Components\Select::make('treatment_id')
                     ->relationship('treatment', 'id')
                     ->required(),

--- a/app/Filament/Resources/TreatmentResource/Pages/CreateTreatment.php
+++ b/app/Filament/Resources/TreatmentResource/Pages/CreateTreatment.php
@@ -3,10 +3,49 @@
 namespace App\Filament\Resources\TreatmentResource\Pages;
 
 use App\Filament\Resources\TreatmentResource;
+use App\Models\Event;
+use Carbon\Carbon;
 use Filament\Actions;
+use Filament\Notifications\Notification;
 use Filament\Resources\Pages\CreateRecord;
+use Illuminate\Database\Eloquent\Model;
 
 class CreateTreatment extends CreateRecord
 {
     protected static string $resource = TreatmentResource::class;
+    protected ?bool $hasDatabaseTransactions = true;
+
+    protected function handleRecordCreation(array $data): Model
+    {
+        $treatment = static::getModel()::create($data);
+        $dataEvent = Event::calculateEvents($treatment);
+        $firstEvent = $dataEvent->first();
+        if ($firstEvent) {
+            $now = Carbon::now();
+            $scheduled_at = Carbon::parse($firstEvent['scheduled_at']);
+
+            $diffInHours = $now->diffInHours($scheduled_at, false);
+            $diffInMinutes = $now->diffInMinutes($scheduled_at, false);
+
+            if ($diffInHours >= 0) {
+                $hours = floor(abs($diffInMinutes) / 60);
+                $minutes = abs($diffInMinutes) % 60;
+                if ($hours < 24) {
+                    $message = "Faltan $hours horas y $minutes minutos para el evento.";
+                } else {
+                    $message = "El evento está programado para el " . $scheduled_at->translatedFormat('d \d\e F \a \l\a\s H:i');
+                }
+            } else {
+                $message = "El evento ya pasó.";
+            }
+            Notification::make()
+                ->title('New event created')
+                ->body($message)
+                ->success()
+                ->send();
+        }
+
+        Event::insert($dataEvent->toArray());
+        return $treatment;
+    }
 }

--- a/app/Filament/Widgets/CalendarWidget.php
+++ b/app/Filament/Widgets/CalendarWidget.php
@@ -2,10 +2,23 @@
 
 namespace App\Filament\Widgets;
 
+use App\Models\Event;
+use App\Models\Treatment;
+use Carbon\Carbon;
+use Filament\Actions\Action;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Log;
 use Saade\FilamentFullCalendar\Widgets\FullCalendarWidget;
+use Filament\Forms;
+use Filament\Support\Colors\Color;
+use Illuminate\Database\Eloquent\Model;
+use Saade\FilamentFullCalendar\Data\EventData;
+use Saade\FilamentFullCalendar\Actions;
+use Filament\Support\Facades\FilamentColor;
 
 class CalendarWidget extends FullCalendarWidget
 {
+    public Model | string | null $model = Event::class;
     protected static ?int $sort = 2;
 
     /**
@@ -14,9 +27,98 @@ class CalendarWidget extends FullCalendarWidget
      */
     public function fetchEvents(array $fetchInfo): array
     {
-        // You can use $fetchInfo to filter events by date.
-        // This method should return an array of event-like objects. See: https://github.com/saade/filament-fullcalendar/blob/3.x/#returning-events
-        // You can also return an array of EventData objects. See: https://github.com/saade/filament-fullcalendar/blob/3.x/#the-eventdata-class
-        return [];
+        $userId = Auth::id();
+        // $colors = Color::all();
+        $colors = FilamentColor::getColors();
+        $treatments = Treatment::with([
+            'events:id,treatment_id,scheduled_at,index',
+            'medicine:id,name'
+        ])
+            ->where('user_id', $userId)
+            ->where('is_active', true)
+            ->select('id', 'medicine_id', 'start_date', 'end_date')
+            ->get();
+        $arrayColorsEvents = [];
+        $usedColors = [];
+
+        $tones = [400, 600, 800];
+        $events = collect();
+        foreach ($treatments as $treatment) {
+            foreach ($tones as $tone) {
+                foreach ($colors as $key => $color) {
+                    if (isset($color[$tone])) {
+                        $rgb = 'rgb(' . $color[$tone] . ')';
+                        if (!in_array($rgb, $usedColors) && !isset($arrayColorsEvents[$treatment->id])) {
+                            $usedColors[] = $rgb;
+                            $arrayColorsEvents[$treatment->id] = $rgb;
+                            $movedColor = array_shift($colors);
+                            array_push($colors, $movedColor);
+                            continue 2;
+                        }
+                    }
+                }
+            }
+            foreach ($treatment->events as $event) {
+                $events->push(
+                    EventData::make()
+                        ->id($event->id)
+                        ->start($event->scheduled_at)
+                        ->end(Carbon::parse($event->scheduled_at)->addSecond()->format('Y-m-d H:i:s'))
+                        ->title($treatment->medicine->name)
+                        ->borderColor($arrayColorsEvents[$treatment->id])
+                );
+            }
+        }
+        return $events->toArray();
+    }
+    protected function headerActions(): array
+    {
+        return [
+            // Actions\CreateAction::make(), //Cancelamos Evento de creacion
+        ];
+    }
+    protected function viewAction(): Action
+    {
+        return Actions\ViewAction::make()
+            ->mutateRecordDataUsing(function (array $data): array {
+                return [
+                    ...$data,
+                    'treatment-start_date' => $this->record->treatment->start_date,
+                    'treatment-end_date' => $this->record->treatment->end_date,
+                    'treatment-medicine-name' => $this->record->treatment->medicine->name,
+                ];
+            });
+    }
+    protected function modalActions(): array
+    {
+        return [
+            Actions\EditAction::make()
+        ];
+    }
+    public function getFormSchema(): array
+    {
+        return [
+            Forms\Components\Section::make('Information Treatment')
+                ->schema([
+                    Forms\Components\DateTimePicker::make('treatment-start_date')
+                        ->label('treatment start date')
+                        ->disabled(),
+                    Forms\Components\DateTimePicker::make('treatment-end_date')
+                        ->label('treatment end date')
+                        ->disabled(),
+                    Forms\Components\TextInput::make('treatment-medicine-name')
+                        ->label('Medicine name')
+                        ->disabled(),
+                ])->columns(2),
+            Forms\Components\Section::make('Information Event')
+                ->schema([
+                    Forms\Components\DateTimePicker::make('scheduled_at')
+                        ->label('scheduled at'),
+                    Forms\Components\TextInput::make('index')
+                        ->label('Event number')
+                        ->numeric()
+                        ->prefix('#')
+                ])->columns(2),
+        ];
     }
 }

--- a/app/Models/Event.php
+++ b/app/Models/Event.php
@@ -2,8 +2,10 @@
 
 namespace App\Models;
 
+use Carbon\Carbon;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Support\Collection;
 
 class Event extends Model
 {
@@ -15,7 +17,11 @@ class Event extends Model
         'notified',
         'route',
         'grade_pain',
-        'feedback'
+        'feedback',
+        'scheduled_at'
+    ];
+    protected $cast = [
+        'scheduled_at' => 'date',
     ];
     /**
      * Get the user that owns the Event
@@ -44,4 +50,48 @@ class Event extends Model
     {
         return $this->belongsTo(Medicine::class);
     }
+    /**
+     * Generates a collection of events scheduled for a given treatment.
+     * @return \Illuminate\Support\Collection
+     * 
+     * @param \App\Models\Treatment $treatment The treatment for which to generate events.
+     * 
+     * @param \App\Models\Event|null $latestEvent The last recorded event, if any.
+     *
+     * @param int $max The maximum number of events to generate. Default is 10
+     */
+    public static function calculateEvents(Treatment $treatment, ?Event $latestEvent = null, int $max = 10): Collection
+    {
+        //Treatment
+        $start_date = Carbon::parse($treatment->start_date);
+        $end_date = Carbon::parse($treatment->end_date);
+        $frequency = $treatment->frequency * 60;
+
+        //LatestEvent
+        $latestEventDate = $latestEvent ? Carbon::parse($latestEvent->scheduled_at) : null;
+
+        //General
+        $index = $latestEvent ? ($latestEvent->index + 1) : 1;
+        $indexLocal = 1;
+        $events = collect();
+
+        $start_date = $latestEvent ? $latestEventDate : $start_date;
+
+        while ($indexLocal <= $max && $start_date <= $end_date) {
+            $start_date->addMinutes($frequency);
+            $event = collect([
+                'treatment_id' => $treatment->id,
+                'user_id' => $treatment->user_id,
+                'scheduled_at' => $start_date->copy(),
+                'index' => $index
+            ]);
+            $events->push($event);
+            $indexLocal++;
+            $index++;
+        }
+
+        return $events;
+    }
+
+
 }

--- a/app/Models/Treatment.php
+++ b/app/Models/Treatment.php
@@ -7,6 +7,7 @@ use App\Enums\TreatmentLocation;
 use App\Enums\TreatmentVialType;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\HasOne;
 
 class Treatment extends Model
@@ -43,13 +44,13 @@ class Treatment extends Model
         ];
     }
     /**
-     * Get the Event that the Treatment belongs to.
+     * Get the Events that the Treatment has many.
      *
-     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
+     * @return \Illuminate\Database\Eloquent\Relations\HasMany
      */
-    public function event(): BelongsTo
+    public function events(): HasMany
     {
-        return $this->belongsTo(Event::class);
+        return $this->hasMany(Event::class);
     }
     /**
      * Get the Medicine that the Treatment belongs to.

--- a/app/Models/Treatment.php
+++ b/app/Models/Treatment.php
@@ -9,6 +9,7 @@ class Treatment extends Model
 {
     //
     protected $fillable = [
+        'user_id',
         'medicine_id',
         'dosage',
         'frequency',

--- a/app/Models/Treatment.php
+++ b/app/Models/Treatment.php
@@ -2,8 +2,12 @@
 
 namespace App\Models;
 
+use App\Enums\TreatmentFirstRoute;
+use App\Enums\TreatmentLocation;
+use App\Enums\TreatmentVialType;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasOne;
 
 class Treatment extends Model
 {
@@ -25,7 +29,28 @@ class Treatment extends Model
         'location',
         'custom_location',
     ];
-
+    protected function casts(): array
+    {
+        return [
+            'start_date' => 'datetime',
+            'end_date' => 'datetime',
+            'is_active' => 'boolean',
+            'frequency' => 'integer',
+            'vial_type' => TreatmentVialType::class,
+            'location' => TreatmentLocation::class,
+            'first_route' => TreatmentFirstRoute::class,
+            'first_route' => TreatmentFirstRoute::class,
+        ];
+    }
+    /**
+     * Get the Event that the Treatment belongs to.
+     *
+     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
+     */
+    public function event(): BelongsTo
+    {
+        return $this->belongsTo(Event::class);
+    }
     /**
      * Get the Medicine that the Treatment belongs to.
      *
@@ -43,5 +68,9 @@ class Treatment extends Model
     public function user(): BelongsTo
     {
         return $this->belongsTo(User::class);
+    }
+    public function latestEvent(): HasOne
+    {
+        return $this->hasOne(Event::class)->latestOfMany();
     }
 }

--- a/app/Providers/Filament/AdminPanelProvider.php
+++ b/app/Providers/Filament/AdminPanelProvider.php
@@ -43,7 +43,7 @@ class AdminPanelProvider extends PanelProvider
             ])
             ->plugins([
                 FilamentFullCalendarPlugin::make()
-                ->timezone('Europe/Madrid')
+                // ->timezone('Europe/Madrid')
                 ->locale('es'),
                 FilamentEditProfilePlugin::make()
                 ->shouldRegisterNavigation(false)

--- a/composer.json
+++ b/composer.json
@@ -14,6 +14,7 @@
         "saade/filament-fullcalendar": "^3.0"
     },
     "require-dev": {
+        "barryvdh/laravel-debugbar": "^3.14",
         "fakerphp/faker": "^1.23",
         "laravel/pail": "^1.1",
         "laravel/pint": "^1.13",

--- a/database/migrations/2024_11_16_220133_drop_medicine_id_from_events_table.php
+++ b/database/migrations/2024_11_16_220133_drop_medicine_id_from_events_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('events', function (Blueprint $table) {
+            $table->dropForeign(['medicine_id']);
+            $table->dropColumn(['medicine_id']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('events', function (Blueprint $table) {
+            //
+        });
+    }
+};

--- a/database/migrations/2024_11_17_002941_add_new_enums_and_scheduled_at_and_index_to_events_table.php
+++ b/database/migrations/2024_11_17_002941_add_new_enums_and_scheduled_at_and_index_to_events_table.php
@@ -1,0 +1,36 @@
+<?php
+
+use App\Enums\EventGradePainEnum;
+use App\Enums\EventStatusEnum;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('events', function (Blueprint $table) {
+            $table->enum('status', EventStatusEnum::all())->default(EventStatusEnum::Pending);
+            $table->dropColumn(['grade_pain']);
+            $table->enum('grade_pain', EventGradePainEnum::all())->nullable();
+            $table->timestamp('scheduled_at');
+            $table->integer('index');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('events', function (Blueprint $table) {
+            //
+            $table->dropColumn(['status', 'grade_pain', 'scheduled_at', 'index']);
+            $table->integer('grade_pain')->nullable();
+        });
+    }
+};

--- a/routes/console.php
+++ b/routes/console.php
@@ -1,8 +1,18 @@
 <?php
 
+use App\Models\Event;
+use App\Models\Treatment;
 use Illuminate\Foundation\Inspiring;
 use Illuminate\Support\Facades\Artisan;
-
+use Illuminate\Support\Facades\Schedule;
 Artisan::command('inspire', function () {
     $this->comment(Inspiring::quote());
 })->purpose('Display an inspiring quote')->hourly();
+
+Schedule::call(function () {
+    $treatments = Treatment::where('is_active', true)->with('latestEvent')->get(['id','user_id', 'frequency', 'start_date', 'end_date']);
+    foreach ($treatments as $treatment) {
+        $events = Event::calculateEvents($treatment, $treatment->latestEvent)->toArray();
+        Event::insert($events);
+    }
+})->daily();

--- a/storage/debugbar/.gitignore
+++ b/storage/debugbar/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore


### PR DESCRIPTION
Incluyo una sugerencia base del wizard del formulario de TreatmentResource.

### Explicación de "Vial Information".

`custom_vial_type` solo sera visible si `vial_type` tiene como valor `Other`

`location` solo sera visible si `vial_type` tiene como valor `Injection`, _Ya que el Enum original de location en la migración tiene valores que se entienden como que solo son inyecciones a mi parecer_.

`first_route` solo sera visible si `location` tiene como valor `Arms` o `Legs`

### Explicación de "Schedule"

`frequency` lo estoy manejando como valor en horas. Teniendo valor mínimo 4 y máximo 120, estos valores se cambian en `App\Enums\TreatmentFrequency` en este Enum se pueden colocar `case` sé que utilizarían sugerencias al usuario.

**En las migraciones se puede usar la funcion all() de los enums**
`$table->enum('status', OrderStatus::all())`